### PR TITLE
types-of-kubernetes-services.md is added

### DIFF
--- a/types-of-kubernetes-services.md
+++ b/types-of-kubernetes-services.md
@@ -1,0 +1,82 @@
+# 🚀 Kubernetes: Types of Services
+
+In Kubernetes, **Services** enable communication between different parts of an application and with external users. This document explains the **three core types of services** in Kubernetes:
+
+---
+
+## 🔹 1. ClusterIP (Default)
+
+- **Scope:** Internal-only
+- **Description:**  
+  The default type of service in Kubernetes. It exposes the service on a **cluster-internal IP**. This means that **only components within the cluster can access the service**—it’s not reachable from outside.
+  
+- **Use Case:**  
+  Ideal for **internal communication** between microservices and pods within the cluster.
+
+- **Pros:**
+  - Secure and isolated by default.
+  - No external exposure needed.
+  
+- **Cons:**
+  - Not accessible from outside the cluster.
+
+---
+
+## 🔸 2. NodePort
+
+- **Scope:** External
+- **Description:**  
+  Exposes the service on **each node’s IP address** at a static port (range: `30000–32767`). Requests coming to `<NodeIP>:<NodePort>` are forwarded to the ClusterIP and then routed to the appropriate pod.
+
+- **Use Case:**  
+  For **external access** without using a cloud load balancer.
+
+- **Pros:**
+  - Simple setup for external access.
+  - Works on bare-metal or self-hosted clusters.
+
+- **Cons:**
+  - Requires **manual port management**.
+  - Limited port range can lead to conflicts.
+  - Not ideal for production-scale deployments.
+
+---
+
+## 🟢 3. LoadBalancer
+
+- **Scope:** External
+- **Description:**  
+  Provisions an **external load balancer** (via cloud provider like AWS, Azure, GCP) and exposes the service externally with a **public IP address**.
+
+- **Use Case:**  
+  For **production workloads** that require reliable public access.
+
+- **Pros:**
+  - Automatically distributes traffic.
+  - Handles scaling and health checks.
+  - Plug-and-play with cloud providers.
+
+- **Cons:**
+  - **Costly**: A load balancer is created **per service**.
+  - Not suitable for a large number of microservices (due to cost).
+
+---
+
+## 📋 Summary Table
+
+| Service Type   | Visibility       | Port Range     | Managed By | Cost          | Best Use Case                             |
+|----------------|------------------|----------------|------------|---------------|--------------------------------------------|
+| **ClusterIP**  | Internal Only     | N/A            | Kubernetes | Free          | Internal microservice communication        |
+| **NodePort**   | External (Manual) | 30000–32767    | User       | Low           | Quick external access during development   |
+| **LoadBalancer** | External (Cloud) | Auto-assigned  | Cloud Provider | High       | Production-ready public service exposure   |
+
+---
+
+## 📌 Final Notes
+
+- For complex workloads, consider using **Ingress Controllers** for smarter traffic routing and to avoid creating multiple LoadBalancers.
+- Choose the right service type based on **security**, **cost**, and **scalability** needs.
+
+---
+
+🔁 *Feel free to contribute improvements or raise issues in this repository!*


### PR DESCRIPTION
This repository explains the three main types of Kubernetes services — ClusterIP, NodePort, and LoadBalancer — with clear use cases, pros and cons, and a comparison table. Perfect for DevOps beginners and Kubernetes learners.