### PR TITLE
create-pod.yaml is added

### DIFF
--- a/manifest-files/create_pod.yaml
+++ b/manifest-files/create_pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: create-mypod
+  labels:
+    user: developer
+spec:
+  containers:
+    - name: pod1
+      image: nginx:1.22.0
+      ports:
+        - containerPort: 80


### PR DESCRIPTION
This YAML manifest defines a simple Kubernetes Pod named create-mypod running an NGINX container (nginx:1.22.0). It's a basic practice file to understand how pods are defined using apiVersion, kind, metadata, and spec. Ideal for beginners learning Kubernetes resource creation.