### PR TITLE
manifest-files/create_test_deployment.yaml is added

### DIFF
--- a/manifest-files/create_test_deployment.yaml
+++ b/manifest-files/create_test_deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  labels:
+    user: developer
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: test-pod
+          image: nginx:1.22.0
+          ports:
+            - containerPort: 80
+


### PR DESCRIPTION
This Kubernetes manifest defines a Deployment named test-deployment that runs 10 replicas of an NGINX container (nginx:1.22.0). It uses matchLabels to manage pods and ensures high availability. A great practice example for understanding scalable and declarative pod management in Kubernetes.